### PR TITLE
moving time inequality to prevent duplicate id on backwards time

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,6 +148,11 @@ func nextId() (int64, error) {
 	defer mu.Unlock()
 
 	ts := milliseconds()
+
+	if ts < *lts {
+		return 0, fmt.Errorf("time is moving backwards, waiting until %d\n", *lts)
+	}
+
 	if *lts == ts {
 		seq = (seq + 1) & sequenceMask
 		if seq == 0 {
@@ -157,10 +162,6 @@ func nextId() (int64, error) {
 		}
 	} else {
 		seq = 0
-	}
-
-	if ts < *lts {
-		return 0, fmt.Errorf("time is moving backwards, waiting until %d\n", *lts)
 	}
 
 	*lts = ts


### PR DESCRIPTION
If time moves backwards so that ts is before lts, the ts/lts equality check
fails and the sequence number is set to 0. If time moves back to the correct
millisecond on the next request, the sequence number at 0 is used, instead of
whatever sequence number it was previously on.

By moving the going-backwards-time check before the inequality, we avoid this.

This was a condition fixed in snowflake back in February or so.
